### PR TITLE
Add custom SubCategory to main "Filter by Function" category in Editor 

### DIFF
--- a/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
+++ b/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
@@ -6,8 +6,6 @@ using UnityEngine;
 
 namespace InfernalRobotics.Gui
 {
-    //using UnityEngine;
-
     [KSPAddon(KSPAddon.Startup.MainMenu, true)]
     public class IREditorCategory : MonoBehaviour
     {
@@ -40,6 +38,7 @@ namespace InfernalRobotics.Gui
 
             PartCategorizer.Icon icon = PartCategorizer.Instance.GetIcon(iconFile);
 
+            //Adding our own subcategory to main filter
             PartCategorizer.Category Filter = PartCategorizer.Instance.filters.Find(f => f.button.categoryName == filterCategory);
             PartCategorizer.AddCustomSubcategoryFilter(Filter, customCategoryName, icon, p => availableParts.Contains(p));
 

--- a/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
+++ b/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
@@ -9,52 +9,42 @@ namespace InfernalRobotics.Gui
     //using UnityEngine;
 
     [KSPAddon(KSPAddon.Startup.MainMenu, true)]
-    public class IRAddonEditorFilter : MonoBehaviour
+    public class IREditorCategory : MonoBehaviour
     {
-        private static List<AvailablePart> avPartItems = new List<AvailablePart>();
-        internal string category = "Filter by Function";
-        internal string subCategoryTitle = "IR Items";
-        internal string defaultTitle = "IR";
-        internal string iconName = "R&D_node_icon_evatech";
-        internal bool filter = true;
+        private static List<AvailablePart> availableParts = new List<AvailablePart>();
 
         void Awake()
         {
-            GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+            GameEvents.onGUIEditorToolbarReady.Add(IRCustomFilter);
 
-            avPartItems.Clear();
+            //create list of parts that have MuMechToggle module in them
+            availableParts.Clear();
             foreach (AvailablePart avPart in PartLoader.LoadedPartsList)
             {
-                if (avPart.name == "kerbalEVA" || avPart.name == "kerbalEVA_RD" || !avPart.partPrefab) continue;
+                if (!avPart.partPrefab) continue;
+
                 MuMechToggle moduleItem = avPart.partPrefab.GetComponent<MuMechToggle>();
                 if (moduleItem)
                 {
-                    avPartItems.Add(avPart);
+                    availableParts.Add(avPart);
                 }
             }
 
         }
 
-        private bool EditorItemsFilter(AvailablePart avPart)
+        private void IRCustomFilter()
         {
-            if (avPartItems.Contains(avPart))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            const string iconFile = "R&D_node_icon_robotics";
+            const string filterCategory = "Filter by Function";
+            const string customCategoryName = "Robotic Parts";
 
-        private void SubCategories()
-        {
+            PartCategorizer.Icon icon = PartCategorizer.Instance.GetIcon(iconFile);
 
-            PartCategorizer.Icon icon = PartCategorizer.Instance.GetIcon(iconName);
-            PartCategorizer.Category Filter = PartCategorizer.Instance.filters.Find(f => f.button.categoryName == category);
-            PartCategorizer.AddCustomSubcategoryFilter(Filter, subCategoryTitle, icon, p => EditorItemsFilter(p));
+            PartCategorizer.Category Filter = PartCategorizer.Instance.filters.Find(f => f.button.categoryName == filterCategory);
+            PartCategorizer.AddCustomSubcategoryFilter(Filter, customCategoryName, icon, p => availableParts.Contains(p));
 
             RUIToggleButtonTyped button = Filter.button.activeButton;
+
             button.SetFalse(button, RUIToggleButtonTyped.ClickType.FORCED);
             button.SetTrue(button, RUIToggleButtonTyped.ClickType.FORCED);
         }

--- a/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
+++ b/InfernalRobotics/InfernalRobotics/Gui/EditorCategory.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using InfernalRobotics.Module;
+using UnityEngine;
+
+namespace InfernalRobotics.Gui
+{
+    //using UnityEngine;
+
+    [KSPAddon(KSPAddon.Startup.MainMenu, true)]
+    public class IRAddonEditorFilter : MonoBehaviour
+    {
+        private static List<AvailablePart> avPartItems = new List<AvailablePart>();
+        internal string category = "Filter by Function";
+        internal string subCategoryTitle = "IR Items";
+        internal string defaultTitle = "IR";
+        internal string iconName = "R&D_node_icon_evatech";
+        internal bool filter = true;
+
+        void Awake()
+        {
+            GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
+
+            avPartItems.Clear();
+            foreach (AvailablePart avPart in PartLoader.LoadedPartsList)
+            {
+                if (avPart.name == "kerbalEVA" || avPart.name == "kerbalEVA_RD" || !avPart.partPrefab) continue;
+                MuMechToggle moduleItem = avPart.partPrefab.GetComponent<MuMechToggle>();
+                if (moduleItem)
+                {
+                    avPartItems.Add(avPart);
+                }
+            }
+
+        }
+
+        private bool EditorItemsFilter(AvailablePart avPart)
+        {
+            if (avPartItems.Contains(avPart))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private void SubCategories()
+        {
+
+            PartCategorizer.Icon icon = PartCategorizer.Instance.GetIcon(iconName);
+            PartCategorizer.Category Filter = PartCategorizer.Instance.filters.Find(f => f.button.categoryName == category);
+            PartCategorizer.AddCustomSubcategoryFilter(Filter, subCategoryTitle, icon, p => EditorItemsFilter(p));
+
+            RUIToggleButtonTyped button = Filter.button.activeButton;
+            button.SetFalse(button, RUIToggleButtonTyped.ClickType.FORCED);
+            button.SetTrue(button, RUIToggleButtonTyped.ClickType.FORCED);
+        }
+    }
+}

--- a/InfernalRobotics/InfernalRobotics/InfernalRobotics.csproj
+++ b/InfernalRobotics/InfernalRobotics/InfernalRobotics.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Logger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Module\MuMechToggle.cs" />
+    <Compile Include="Gui\EditorCategory.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Image\counterclockwise.png" />

--- a/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
@@ -234,6 +234,8 @@ namespace InfernalRobotics.Module
         [KSPEvent(guiActive = true, guiActiveEditor = true, guiName = "Rotate Limits are Off", active = false)]
         public void LimitTweakableToggle()
         {
+            if (!rotateJoint)
+                return;
             limitTweakableFlag = !limitTweakableFlag;
             Events["LimitTweakableToggle"].guiName = limitTweakableFlag ? "Rotate Limits are On" : "Rotate Limits are Off";
             if (!limitTweakableFlag)
@@ -556,24 +558,18 @@ namespace InfernalRobotics.Module
 
         private void UpdateMinMaxTweaks()
         {
-            if (rotateJoint)
-            {
-                var rangeMinF = (UI_FloatEdit) Fields["minTweak"].uiControlEditor;
-                rangeMinF.minValue = rotateMin;
-                rangeMinF.maxValue = rotateMax;
-                var rangeMaxF = (UI_FloatEdit) Fields["maxTweak"].uiControlEditor;
-                rangeMaxF.minValue = rotateMin;
-                rangeMaxF.maxValue = rotateMax;
-            }
-            else
-            {
-                var rangeMinF = (UI_FloatEdit) Fields["minTweak"].uiControlEditor;
-                rangeMinF.minValue = translateMin;
-                rangeMinF.maxValue = translateMax;
-                var rangeMaxF = (UI_FloatEdit) Fields["maxTweak"].uiControlEditor;
-                rangeMaxF.minValue = translateMin;
-                rangeMaxF.maxValue = translateMax;
-            }
+            var isEditor = (HighLogic.LoadedSceneIsEditor);
+
+            var rangeMinF = isEditor? (UI_FloatEdit) Fields["minTweak"].uiControlEditor :(UI_FloatEdit) Fields["minTweak"].uiControlFlight;
+            var rangeMaxF = isEditor? (UI_FloatEdit) Fields["maxTweak"].uiControlEditor :(UI_FloatEdit) Fields["maxTweak"].uiControlFlight;
+
+            rangeMinF.minValue = rotateJoint ? rotateMin : translateMin;
+            rangeMinF.maxValue = rotateJoint ? rotateMax : translateMax;
+            rangeMaxF.minValue = rotateJoint ? rotateMin : translateMin;
+            rangeMaxF.maxValue = rotateJoint ? rotateMax : translateMax;
+
+            Logger.Log (string.Format ("UpdateTweaks: rotateJoint = {0}, rotateMin={1}, rotateMax={2}, translateMin={3}, translateMax={4}",
+                rotateJoint, rotateMin, rotateMax, translateMin, translateMax), Logger.Level.Debug);
         }
 
 
@@ -745,7 +741,7 @@ namespace InfernalRobotics.Module
 
             ParsePresetPositions();
 
-            Logger.Log("[MMT] OnStart End, rotateLimits=" + rotateLimits + ", minTweak=" + minTweak + ", maxTweak=" + maxTweak, Logger.Level.Debug);
+            Logger.Log("[MMT] OnStart End, rotateLimits=" + rotateLimits + ", minTweak=" + minTweak + ", maxTweak=" + maxTweak + ", rotateJoint = " + rotateJoint, Logger.Level.Debug);
         }
 
         public void ConfigureInterpolator()


### PR DESCRIPTION
Just like ordinary user-customizable category, but this one scans on application start for all parts that have MuMechToggle module and adds them in the list.

Inspired by KIS and Filter Extensions mods