### PR TITLE
Presets with inverted servos fix + more

### DIFF
--- a/InfernalRobotics/InfernalRobotics/Command/Interpolator.cs
+++ b/InfernalRobotics/InfernalRobotics/Command/Interpolator.cs
@@ -17,6 +17,7 @@ namespace InfernalRobotics.Command
             Active = false;
             CmdVelocity = 0f;
             CmdPosition = 0f;
+            Initialised = false;
         }
 
         #region dynamic state
@@ -46,6 +47,8 @@ namespace InfernalRobotics.Command
         public float MaxAcceleration { get; set; }
 
         public bool IsModulo { get; set; }
+
+        public bool Initialised { get; set; }
 
         #endregion config
 

--- a/InfernalRobotics/InfernalRobotics/Command/Translator.cs
+++ b/InfernalRobotics/InfernalRobotics/Command/Translator.cs
@@ -16,16 +16,14 @@ namespace InfernalRobotics.Command
 
     public class Translator
     {
-        public void Init(Interpolator interpolator, bool axisInversion, bool motionLock, MuMechToggle servo)
+        public void Init(bool axisInversion, bool motionLock, MuMechToggle servo)
         {
-            Interpolator = interpolator;
             IsAxisInverted = axisInversion;
             IsMotionLock = motionLock;
             Servo = servo;
         }
 
         public MuMechToggle Servo;
-        protected Interpolator Interpolator;
 
         // conversion data
         public bool IsAxisInverted;
@@ -37,24 +35,29 @@ namespace InfernalRobotics.Command
         }
 
         // external interface
+        /// <summary>
+        /// Move the servo to the specified pos and speed.
+        /// </summary>
+        /// <param name="pos">Position in external coordinates</param>
+        /// <param name="speed">Speed as multiplier</param>
         public void Move(float pos, float speed)
         {
-            if (!Interpolator.Active)
+            if (!Servo.Interpolator.Active)
                 Servo.ConfigureInterpolator();
 
             if (!IsMotionLock)
-                Interpolator.SetCommand(ToInternalPos(pos), speed * GetSpeedUnit());
+                Servo.Interpolator.SetCommand(ToInternalPos(pos), speed * GetSpeedUnit());
             else
-                Interpolator.SetCommand(0, 0);
+                Servo.Interpolator.SetCommand(0, 0);
         }
 
         public void MoveIncremental(float posDelta, float speed)
         {
-            if (!Interpolator.Active)
+            if (!Servo.Interpolator.Active)
                 Servo.ConfigureInterpolator();
 
             float axisCorrection = IsAxisInverted ? -1 : 1;
-            Interpolator.SetIncrementalCommand(posDelta*axisCorrection, speed * GetSpeedUnit());
+            Servo.Interpolator.SetIncrementalCommand(posDelta*axisCorrection, speed * GetSpeedUnit());
         }
 
         public void Stop()
@@ -64,20 +67,20 @@ namespace InfernalRobotics.Command
 
         public bool IsMoving()
         {
-            return Interpolator.Active && (Interpolator.CmdVelocity != 0f);
+            return Servo.Interpolator.Active && (Servo.Interpolator.CmdVelocity != 0f);
         }
 
         public float ToInternalPos(float externalPos)
         {
             if (IsAxisInverted)
-                return Interpolator.MinPosition + Interpolator.MaxPosition - externalPos;
+                return Servo.MinPosition + Servo.MaxPosition - externalPos;
             else
                 return externalPos;
         }
         public float ToExternalPos(float internalPos)
         {
             if (IsAxisInverted)
-                return Interpolator.MinPosition + Interpolator.MaxPosition - internalPos;
+                return Servo.MinPosition + Servo.MaxPosition - internalPos;
             else
                 return internalPos;
         }

--- a/InfernalRobotics/InfernalRobotics/Gui/ControlsGUI.cs
+++ b/InfernalRobotics/InfernalRobotics/Gui/ControlsGUI.cs
@@ -718,7 +718,13 @@ namespace InfernalRobotics.Gui
                             nameStyle.fontStyle = FontStyle.Italic;
                             nameStyle.alignment = TextAnchor.MiddleCenter;
 
-                            GUILayout.Label(string.Format("{0:#0.##}", servo.Position), nameStyle, GUILayout.Width(45), GUILayout.Height(BUTTON_HEIGHT));
+                            var posStyle = new GUIStyle (nameStyle);
+                            if(servo.Translator.IsAxisInverted)
+                            {
+                                posStyle.fontStyle = FontStyle.Italic;
+                                posStyle.normal.textColor = new Color (1, 1, 0);
+                            }
+                            GUILayout.Label(string.Format("{0:#0.##}", servo.Translator.ToExternalPos(servo.Position)), posStyle, GUILayout.Width(45), GUILayout.Height(BUTTON_HEIGHT));
 
                             bool servoLocked = servo.isMotionLock;
                             servoLocked = GUILayout.Toggle(servoLocked,
@@ -785,7 +791,7 @@ namespace InfernalRobotics.Gui
                                     g.MovingPositive = false;
                                     g.ButtonDown = true;
 
-                                    servo.Translator.Move(0f, servo.customSpeed * servo.speedTweak);
+                                    servo.Translator.Move(servo.Translator.ToExternalPos(0f), servo.customSpeed * servo.speedTweak);
                                 }
                                 SetTooltipText();
 
@@ -1105,7 +1111,7 @@ namespace InfernalRobotics.Gui
 
                 GUILayout.Space(25);
 
-                GUILayout.Label("Pos.", GUILayout.Width(30), rowHeight);
+                GUILayout.Label("Pos.", GUILayout.Width(40), rowHeight);
 
                 if (isEditor)
                     GUILayout.Label("Move", GUILayout.Width(45), rowHeight);
@@ -1159,7 +1165,13 @@ namespace InfernalRobotics.Gui
                         }
                         SetTooltipText();
 
-                        GUILayout.Label(string.Format("{0:#0.##}", servo.Position), GUILayout.Width(30), rowHeight);
+                        var posStyle = new GUIStyle (GUI.skin.label);
+                        if(servo.Translator.IsAxisInverted)
+                        {
+                            posStyle.fontStyle = FontStyle.Italic;
+                            posStyle.normal.textColor = new Color (1, 1, 0);
+                        }
+                        GUILayout.Label(string.Format("{0:#0.##}", servo.Translator.ToExternalPos(servo.Position)), posStyle, GUILayout.Width(40), rowHeight);
 
                         //individual servo movement when in editor
                         if (isEditor)
@@ -1306,7 +1318,7 @@ namespace InfernalRobotics.Gui
             GUILayout.BeginVertical();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Preset position", GUILayout.ExpandWidth(true), rowHeight);
+            GUILayout.Label("Preset position" + (servoTweak.Translator.IsAxisInverted ? " (Inv axis)" :""), GUILayout.ExpandWidth(true), rowHeight);
             if (GUILayout.Button("Add", buttonStyle, GUILayout.Width(30), rowHeight))
             {
                 servoTweak.PresetPositions.Add(servoTweak.Position);
@@ -1319,11 +1331,12 @@ namespace InfernalRobotics.Gui
             {
                 GUILayout.BeginHorizontal();
                 GUI.SetNextControlName("Preset " + i);
-                string tmp = GUILayout.TextField(string.Format("{0:#0.0#}", servoTweak.PresetPositions[i]), GUILayout.ExpandWidth(true), rowHeight);
+                string tmp = GUILayout.TextField(string.Format("{0:#0.0#}", servoTweak.Translator.ToExternalPos(servoTweak.PresetPositions[i])), GUILayout.ExpandWidth(true), rowHeight);
 
                 float tmpValue;
                 if (float.TryParse(tmp, out tmpValue))
                 {
+                    tmpValue = servoTweak.Translator.ToInternalPos (tmpValue);
                     tmpValue = Mathf.Clamp(tmpValue, servoTweak.minTweak, servoTweak.maxTweak);
                     servoTweak.PresetPositions[i] = tmpValue;
                 }
@@ -1688,7 +1701,7 @@ namespace InfernalRobotics.Gui
                 {
                     foreach (MuMechToggle servo in Servos)
                     {
-                        servo.Translator.Move(0f, servo.customSpeed * servo.speedTweak); //TODO: to be precise this should be not Zero but a default rotation/translation as set in VAB/SPH
+                        servo.Translator.Move(servo.Translator.ToExternalPos(0f), servo.customSpeed * servo.speedTweak); //TODO: to be precise this should be not Zero but a default rotation/translation as set in VAB/SPH
                     }
                 }
             }

--- a/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
@@ -1165,6 +1165,21 @@ namespace InfernalRobotics.Module
             SetLock(!isMotionLock);
         }
 
+        public void MoveToPreset(int presetIndex, float delta=0)
+        {
+            if (PresetPositions == null || PresetPositions.Count == 0 
+                || presetIndex < 0 || presetIndex > PresetPositions.Count) 
+                return;
+
+            float nextPosition = PresetPositions[presetIndex] + delta;
+
+            //because Translator expects position in external coordinates
+            nextPosition = Translator.ToExternalPos (nextPosition);
+
+            Logger.Log ("[Action] MoveToPreset, index=" + presetIndex + " currentPos = " + Position + ", nextPosition=" + nextPosition, Logger.Level.Debug);
+            Translator.Move(nextPosition, customSpeed * speedTweak);
+        }
+
         /// <summary>
         /// Moves to the next preset. 
         /// Presets and position are assumed to be in internal coordinates.

--- a/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
@@ -1219,13 +1219,11 @@ namespace InfernalRobotics.Module
             else if (!limitTweakableFlag)
             {
                 //part is unrestricted, we can choose first preset
-                nextPosition = Translator.IsAxisInverted ?  (Translator.ToExternalPos (PresetPositions.Min()) + 360) 
-                    : (Translator.ToExternalPos (PresetPositions.Max())-360);
+                nextPosition = Translator.IsAxisInverted ?  (PresetPositions.Min() + 360) 
+                    : (PresetPositions.Max()-360);
             }
-            else
-            {
-                nextPosition = Translator.ToExternalPos (nextPosition);
-            }
+            //because Translator expects position in external coordinates
+            nextPosition = Translator.ToExternalPos (nextPosition);
 
             Logger.Log ("[Action] PrevPreset, currentPos = " + Position + ", nextPosition=" + nextPosition, Logger.Level.Debug);
 

--- a/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
+++ b/InfernalRobotics/InfernalRobotics/Module/MuMechToggle.cs
@@ -1176,6 +1176,8 @@ namespace InfernalRobotics.Module
 
         public void MoveNextPreset()
         {
+            if (PresetPositions == null || PresetPositions.Count == 0) return;
+
             float currentPosition = Interpolator.Position;
             float nextPosition = currentPosition;
 
@@ -1196,6 +1198,8 @@ namespace InfernalRobotics.Module
 
         public void MovePrevPreset()
         {
+            if (PresetPositions == null || PresetPositions.Count == 0) return;
+
             float currentPosition = Interpolator.Position;
             float nextPosition = currentPosition;
 


### PR DESCRIPTION
Inverted servo's position is now displayed correctly in UI and highlighted in yellow (reflects the inverted range), meaning that [0,180] range servo positioned at 0 becomes [0,180] servo positioned at 180 and moving backwards. Preset buttons now respect servo inversion too (before they worked via some unexplained magic, jk).

If the rotating limits are off, then Next/Prev preset buttons loop through available presets. Known issue is some wiggle when looping from last preset of current range to the first preset on next range.

Removed redundant Interpolator from Translator, as it can be accessed through Translator.Servo.Interpolator easily.

Made MinPosition/MaxPosition attributes available to be read without Interpolator (so it works in Editor too, where Interpolator is not yet initialised).

